### PR TITLE
Feat: VS-Code server application

### DIFF
--- a/apps/vscode/0.10.1/Readme.md
+++ b/apps/vscode/0.10.1/Readme.md
@@ -1,0 +1,8 @@
+# VSCode - Open source Code Editor 
+
+This application hosts a vscode-server on browser ready to use integrated with NodeJS and Playground CLI to bootstrap applications.
+
+Steps:
+1. Select catalog application.
+2. Change password and sudoPassword in base64 format. (default is `password`)
+3. Deploy the application.

--- a/apps/vscode/0.10.1/vscode-oam.yaml
+++ b/apps/vscode/0.10.1/vscode-oam.yaml
@@ -28,7 +28,7 @@ spec:
               PGID: "1000"
               TZ: "Asia/Kolkata"
               DEFAULT_WORKSPACE: "/config/workspace"
-    - name: vsocde-playground 
+    - name: vscode-playground 
       dependsOn:
         - vscode-configurations
       type: webservice

--- a/apps/vscode/0.10.1/vscode-oam.yaml
+++ b/apps/vscode/0.10.1/vscode-oam.yaml
@@ -35,7 +35,7 @@ spec:
       traits:
         - type: napptive-ingress
           properties:
-            name: nginx-ingress 
+            name: vscode 
             port: 8443 
             path: /
         - type: storage

--- a/apps/vscode/0.10.1/vscode-oam.yaml
+++ b/apps/vscode/0.10.1/vscode-oam.yaml
@@ -1,0 +1,86 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application 
+metadata:
+  name: vscode-playground
+  annotations:
+    version: playground
+    description: "VSCode IDE with Playground CLI"
+spec:
+  components:
+    - name: vscode-configurations
+      type: k8s-objects
+      properties:
+        objects:
+          - apiVersion: v1 
+            kind: Secret
+            metadata:
+              name: vscode-secrets
+            type: Opaque
+            data:
+              password: cGFzc3dvcmQ=
+              sudoPass: c3VwZXJzZWNyZXRwYXNzd29yZA==
+          - apiVersion: v1 
+            kind: ConfigMap 
+            metadata:
+              name: vscode-configs 
+            data: 
+              PUID: "1000"
+              PGID: "1000"
+              TZ: "Asia/Kolkata"
+              DEFAULT_WORKSPACE: "/config/workspace"
+    - name: vsocde-playground 
+      dependsOn:
+        - vscode-configurations
+      type: webservice
+      traits:
+        - type: napptive-ingress
+          properties:
+            name: nginx-ingress 
+            port: 8443 
+            path: /
+        - type: storage
+          properties:
+            pvc:
+              - name: vscode-pvc
+                mountPath: /config
+                resources:
+                  requests:
+                    storage: 1Gi
+      properties:
+        image: napptive/vscode-server
+        cpu: "500m"
+        memory: 2G
+        ports: 
+          - port: 8443
+            expose: true 
+        env:
+          - name: PUID
+            valueFrom:
+              configMapKeyRef:
+                name: vscode-configs
+                key: PUID
+          - name: PGID
+            valueFrom:
+              configMapKeyRef:
+                name: vscode-configs
+                key: PGID
+          - name: TZ
+            valueFrom:  
+              configMapKeyRef:
+                name: vscode-configs
+                key: TZ
+          - name: DEFAULT_WORKSPACE
+            valueFrom:
+              configMapKeyRef:
+                name: vscode-configs
+                key: DEFAULT_WORKSPACE
+          - name: PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: vscode-secrets
+                key: password
+          - name: SUDO_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: vscode-secrets
+                key: sudoPass

--- a/apps/vscode/0.10.1/vscode-oam.yaml
+++ b/apps/vscode/0.10.1/vscode-oam.yaml
@@ -47,7 +47,7 @@ spec:
                   requests:
                     storage: 1Gi
       properties:
-        image: napptive/vscode-server
+        image: napptive/vscode-server:v1.82-pg-v6.0.2
         cpu: "500m"
         memory: 2G
         ports: 

--- a/apps/vscode/0.10.1/vscode.meta.yaml
+++ b/apps/vscode/0.10.1/vscode.meta.yaml
@@ -1,0 +1,20 @@
+apiVersion: core.napptive.com/v1alpha1
+kind: ApplicationMetadata
+# Name of the application, not necessarily a valid k8s name.
+name: "VSCode - Playground"
+version: 0.10.1
+description: VSCode is a fully flexible open-source code-editor.
+# Keywords facilitate searches on the catalog
+keywords:
+  - "code-editor"
+  - "vscode"
+  - "IDE" 
+license: "Apache License Version 2.0"
+url: "https://hub.docker.com/r/linuxserver/code-server"
+doc: "https://hub.docker.com/r/linuxserver/code-server"
+
+logo:
+  - src: "https://e7.pngegg.com/pngimages/100/690/png-clipart-visual-studio-code-microsoft-visual-studio-source-code-text-editor-microsoft-blue-angle-thumbnail.png"
+    type: "image/png"
+    size: "348x348"
+

--- a/containers/vs-code/v1.82-pg-v6.0.2/Dockerfile
+++ b/containers/vs-code/v1.82-pg-v6.0.2/Dockerfile
@@ -1,0 +1,21 @@
+FROM lscr.io/linuxserver/code-server:latest
+
+USER root 
+
+# Install playground-CLI
+RUN curl -O https://storage.googleapis.com/artifacts.playground.napptive.dev/installer.sh && bash installer.sh
+
+# Install NodeJS
+RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - && \
+    apt-get install -y nodejs \
+    build-essential && \
+    node --version && \
+    npm --version
+
+RUN mkdir -p /extensions/code-server/extensions && chmod -R  777 /extensions
+
+RUN echo  'export XDG_DATA_HOME=/extensions' >> /etc/profile
+
+RUN useradd -ms /bin/bash coder
+
+ENV XDG_DATA_HOME=/extensions

--- a/containers/vs-code/v1.82-pg-v6.0.2/Readme.md
+++ b/containers/vs-code/v1.82-pg-v6.0.2/Readme.md
@@ -1,0 +1,5 @@
+# Instructions on building Dockerfile
+
+`docker build -t <username>/vscode-server .`
+
+NOTE: Extension path is already configured in Dockerfile

--- a/containers/vs-code/v1.82-pg-v6.0.2/steps.txt
+++ b/containers/vs-code/v1.82-pg-v6.0.2/steps.txt
@@ -1,0 +1,21 @@
+1. Build dockerfile
+docker build -t <username>/vscode-server .  
+
+2. Upload dockerfile
+docker push <username>/vscode-server
+
+3. Deploy GOGS from catalog 
+
+4. Deploy vscode from yaml
+
+5. Login to playground CLI inside vscode container (password=password and sudo-password=supersecretpassword)
+
+6. Write application. Here we are using same vscode-application yaml with modified name for testing.
+
+7. Push code to GOGS.
+configure:
+git config --global user.name "Nimish Kashyap"
+git config --global user.email "<your_email_id>"
+
+8. Use playground CLI to deloy the application (both using YAML and catalog)
+Use app.oam to deploy the application


### PR DESCRIPTION
### Checklist

- [x] Application license is compatible
- [x] I have created a directory in the form of `apps/<application_name>/<version>`
- [x] I have added the corresponding [metadata](https://docs.napptive.com/catalog/application_metadata.html) file
- [x] I have added the corresponding README file
- [x] I have tested the application in my own namespace and works as expected
- [x] I have tested that the application can be uploaded to my catalog namespace

#### What does this PR do?
Adds browser based VS-Code application to  the catalog.

#### Which as the minimum requirements to launch the application?
This application requires at least 1 GB of PVC storage (can be used with emptyDir storage as well but not recommended), 2 GB of RAM and 1 Core vCPU.

#### Any background context you want to provide

This is an updated PR with git tree fixed.

#### Screenshots (if appropriate)

