### PR TITLE
feat: onlyoffice added

### DIFF
--- a/apps/onlyoffice-docserver/0.1.0/README.md
+++ b/apps/onlyoffice-docserver/0.1.0/README.md
@@ -1,11 +1,11 @@
 # OnlyOffice Suite
 
-This OAM application hosts OnlyOffice Suite on Napptive with minimal configuration.
+This OAM application hosts OnlyOffice Suite Document Server on Napptive with minimal configuration.
 
 Resources Requirement: 
-- CPU: 1vCPU
-- RAM: 5GB
-- Storage: 3GB (can be modified)
+- CPU: 2vCPU
+- RAM: 7GB
+- Storage: 4GB (can be modified)
 
 Steps: 
 1. Select application from catalog. 

--- a/apps/onlyoffice-docserver/0.1.0/README.md
+++ b/apps/onlyoffice-docserver/0.1.0/README.md
@@ -1,0 +1,17 @@
+# OnlyOffice Suite
+
+This OAM application hosts OnlyOffice Suite on Napptive with minimal configuration.
+
+Resources Requirement: 
+- CPU: 1vCPU
+- RAM: 5GB
+- Storage: 3GB (can be modified)
+
+Steps: 
+1. Select application from catalog. 
+2. Modify parameters (if required)
+3. Deploy and wait for each component to start-up
+4. Open the OnlyOffice URL and start example.
+5. Start using the application.
+ 
+NOTE: Backend application requires at-least 5 minutes to start

--- a/apps/onlyoffice-docserver/0.1.0/README.md
+++ b/apps/onlyoffice-docserver/0.1.0/README.md
@@ -14,4 +14,4 @@ Steps:
 4. Open the OnlyOffice URL and start example.
 5. Start using the application.
  
-NOTE: Backend application requires at-least 5 minutes to start
+NOTE: This OAM file hosts Document Server of OnlyOffice and is required to be integrated using OnlyOffice Groups.

--- a/apps/onlyoffice-docserver/0.1.0/onlyoffice.application.yaml
+++ b/apps/onlyoffice-docserver/0.1.0/onlyoffice.application.yaml
@@ -31,6 +31,14 @@ spec:
             value: onlyoffice
           - name: AMQP_URI
             value: amqp://guest:guest@onlyoffice-rabbitmq
+          - name: JWT_ENABLED
+            value: "true"
+          - name: JWT_SECRET
+            value: "my-secret"
+          - name: JWT_HEADER
+            value: Authorization
+          - name: JWT_IN_BODY
+            value: "true"
       traits:
         - type: lifecycle
           properties:

--- a/apps/onlyoffice-docserver/0.1.0/onlyoffice.application.yaml
+++ b/apps/onlyoffice-docserver/0.1.0/onlyoffice.application.yaml
@@ -1,0 +1,108 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: onlyoffice-deployment
+spec:
+  components:
+    - name: onlyoffice-documentserver
+      dependsOn:
+        - onlyoffice-db
+        - onlyoffice-rabbitmq
+      type: webservice
+      properties:
+        image: onlyoffice/documentserver
+        cpu: "1"
+        memory: "4Gi"
+        ports:
+          - port: 80
+            expose: true
+          - port: 443
+            expose: true
+        env:
+          - name: DB_TYPE
+            value: postgres
+          - name: DB_HOST
+            value: onlyoffice-db
+          - name: DB_PORT
+            value: "5432"
+          - name: DB_NAME
+            value: onlyofficedb
+          - name: DB_USER
+            value: onlyoffice
+          - name: AMQP_URI
+            value: amqp://guest:guest@onlyoffice-rabbitmq
+      traits:
+        - type: lifecycle
+          properties:
+            postStart:
+              exec:
+                command:
+                  [
+                    "/bin/bash",
+                    "-c",
+                    "sleep 30 && sudo supervisorctl start ds:example && sudo sed 's,autostart=false,autostart=true,' -i /etc/supervisor/conf.d/ds-example.conf",
+                  ]
+        - type: napptive-ingress
+          properties:
+            name: onlyoffice-ingress
+            port: 80
+            path: /
+        - type: storage
+          properties:
+            pvc:
+              - name: office-log-pvc
+                mountPath: /var/log/onlyoffice
+                resources:
+                  requests:
+                    storage: 512Mi
+              - name: office-data-pvc
+                mountPath: /var/www/onlyoffice/Data
+                resources:
+                  requests:
+                    storage: 1Gi
+              - name: officelib
+                mountPath: /var/lib/onlyoffice
+                resources:
+                  requests:
+                    storage: 256Mi
+              - name: office-font
+                mountPath: /usr/share/fonts
+                resources:
+                  requests:
+                    storage: 100Mi
+    - name: onlyoffice-rabbitmq
+      type: webservice
+      properties:
+        image: rabbitmq
+        cpu: "150m"
+        memory: "1Gi"
+        ports:
+          - port: 5672
+            expose: true
+
+    - name: onlyoffice-db
+      type: webservice
+      properties:
+        image: "postgres:9.5"
+        cpu: "250m"
+        memory: "1Gi"
+        ports:
+          - port: 5432
+            expose: true
+        env:
+          - name: POSTGRES_DB
+            value: onlyofficedb
+          - name: POSTGRES_USER
+            value: onlyoffice
+          - name: POSTGRES_HOST_AUTH_METHOD
+            value: trust
+      traits:
+        - type: storage
+          properties:
+            pvc:
+              - name: postgres-db-pvc
+                mountPath: /var/lib/postgresql/data
+                subPath: postgres
+                resources:
+                  requests:
+                    storage: 1Gi

--- a/apps/onlyoffice-docserver/0.1.0/onlyoffice.meta.yaml
+++ b/apps/onlyoffice-docserver/0.1.0/onlyoffice.meta.yaml
@@ -1,0 +1,18 @@
+apiVersion: core.napptive.com/v1alpha1
+kind: ApplicationMetadata
+name: "OnlyOfficeDocs"
+version: 0.1.0
+description: Open source document editing tool
+keywords:
+  - "document editing tool"
+  - "docx"
+  - "ppt"
+  - "csv"
+license: "Apache License Version 2.0"
+url: "https://www.onlyoffice.com/"
+doc: "https://helpcenter.onlyoffice.com/installation/docs-community-install-docker.aspx"
+
+logo:
+  - src: "https://download.onlyoffice.com/assets/fb/fb_icon_325x325.jpg"
+    type: "image/jpg"
+    size: "325x325"


### PR DESCRIPTION
### Checklist

- [x] Application license is compatible
- [x] I have created a directory in the form of `apps/<application_name>/<version>`
- [x] I have added the corresponding [metadata](https://docs.napptive.com/catalog/application_metadata.html) file
- [x] I have added the corresponding README file
- [x] I have tested the application in my own namespace and works as expected
- [x] I have tested that the application can be uploaded to my catalog namespace

#### What does this PR do?
This PR adds Onlyoffice Document Server to Napptive Catalog.

#### Which as the minimum requirements to launch the application?
- 1vCPU
- RAM: 5GB
- Storage: 3GB
#### Any background context you want to provide?

#### Screenshots (if appropriate)

